### PR TITLE
prefers-color-scheme: light fix

### DIFF
--- a/src/components/repos/RepoItem.jsx
+++ b/src/components/repos/RepoItem.jsx
@@ -14,7 +14,7 @@ function RepoItem({ repo }) {
   } = repo
 
   return (
-    <div className='mb-2 rounded-md card bg-gray-800 hover:bg-gray-900'>
+    <div className='mb-2 rounded-md card bg-base-200 hover:bg-base-300'>
       <div className='card-body'>
         <h3 className='mb-2 text-xl font-semibold'>
           <a href={html_url}>


### PR DESCRIPTION
When the browser's preferred color scheme is light, the gray background is too dark on the RepoItem component, and the content is not visible.

Using base-200 and base-300 backgrounds, will make the component's background change according to the browser's preference.